### PR TITLE
Add DNS record for `dashboard` subdomain

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -80,3 +80,11 @@ resource "aws_route53_record" "docs" {
   ttl     = "300"
   records = ["lincbrain.github.io."]
 }
+
+resource "aws_route53_record" "dashboard" {
+  zone_id = aws_route53_zone.linc-brain-mit.zone_id
+  name    = "dashboard"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["lincbrain.github.io."]
+}


### PR DESCRIPTION
- [x] Depends on https://github.com/lincbrain/linc-dashboard/pull/12.
- [x] Once https://github.com/lincbrain/linc-dashboard/pull/12 is merged, will need to removed the `A` record from Route53.

cc @satra