### PR TITLE
Set environment vars to set vendor-specific dandi-schema used by the DANDI instance

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -36,10 +36,6 @@ module "api" {
         DJANGO_DANDI_DANDISETS_EMBARGO_BUCKET_PREFIX   = ""
         DJANGO_DANDI_DANDISETS_LOG_BUCKET_NAME         = module.sponsored_lincset_bucket_us_east_2.log_bucket_name
         DJANGO_DANDI_DANDISETS_EMBARGO_LOG_BUCKET_NAME = module.sponsored_embargo_bucket_us_east_2.log_bucket_name
-        DJANGO_DANDI_DOI_API_URL                       = "https://api.datacite.org/dois"
-        DJANGO_DANDI_DOI_API_USER                      = "temp.dandi"
-        DJANGO_DANDI_DOI_API_PREFIX                    = "temp"
-        DJANGO_DANDI_DOI_PUBLISH                       = "true"
         DJANGO_SENTRY_DSN                              = "https://833c159dc622528b21b4ce4adef6dbf8@o4506237212033024.ingest.sentry.io/4506237213212672"
         DJANGO_SENTRY_ENVIRONMENT                      = "production"
         DJANGO_CELERY_WORKER_CONCURRENCY               = "4"
@@ -51,7 +47,6 @@ module "api" {
         WEBKNOSSOS_ORGANIZATION_NAME                   = "LINC"
       }
       additional_sensitive_django_vars = {
-        DJANGO_DANDI_DOI_API_PASSWORD = "temp"
       }
 }
 

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -39,7 +39,7 @@ module "api" {
         DJANGO_SENTRY_DSN                              = "https://833c159dc622528b21b4ce4adef6dbf8@o4506237212033024.ingest.sentry.io/4506237213212672"
         DJANGO_SENTRY_ENVIRONMENT                      = "production"
         DJANGO_CELERY_WORKER_CONCURRENCY               = "4"
-        DJANGO_DANDI_INSTANCE_NAME                     = "DANDI"
+        DJANGO_DANDI_INSTANCE_NAME                     = "LINC"
         DJANGO_DANDI_WEB_APP_URL                       = "https://lincbrain.org"
         DJANGO_DANDI_API_URL                           = "https://api.lincbrain.org"
         DJANGO_DANDI_JUPYTERHUB_URL                    = "https://hub.dandiarchive.org"

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -39,6 +39,7 @@ module "api" {
         DJANGO_SENTRY_DSN                              = "https://833c159dc622528b21b4ce4adef6dbf8@o4506237212033024.ingest.sentry.io/4506237213212672"
         DJANGO_SENTRY_ENVIRONMENT                      = "production"
         DJANGO_CELERY_WORKER_CONCURRENCY               = "4"
+        DJANGO_DANDI_INSTANCE_NAME                     = "DANDI"
         DJANGO_DANDI_WEB_APP_URL                       = "https://lincbrain.org"
         DJANGO_DANDI_API_URL                           = "https://api.lincbrain.org"
         DJANGO_DANDI_JUPYTERHUB_URL                    = "https://hub.dandiarchive.org"

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -38,7 +38,7 @@ module "api_staging" {
     DJANGO_SENTRY_DSN                              = "https://833c159dc622528b21b4ce4adef6dbf8@o4506237212033024.ingest.sentry.io/4506237213212672"
     DJANGO_SENTRY_ENVIRONMENT                      = "staging"
     DJANGO_CELERY_WORKER_CONCURRENCY               = "2"
-    DJANGO_DANDI_INSTANCE_NAME                     = "DANDI-STAGING"
+    DJANGO_DANDI_INSTANCE_NAME                     = "LINC-STAGING"
     DJANGO_DANDI_WEB_APP_URL                       = "https://staging--lincbrain-org.netlify.app"
     DJANGO_DANDI_API_URL                           = "https://staging-api.lincbrain.org"
     DJANGO_DANDI_JUPYTERHUB_URL                    = "https://hub.dandiarchive.org/"

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -38,6 +38,7 @@ module "api_staging" {
     DJANGO_SENTRY_DSN                              = "https://833c159dc622528b21b4ce4adef6dbf8@o4506237212033024.ingest.sentry.io/4506237213212672"
     DJANGO_SENTRY_ENVIRONMENT                      = "staging"
     DJANGO_CELERY_WORKER_CONCURRENCY               = "2"
+    DJANGO_DANDI_INSTANCE_NAME                     = "DANDI-STAGING"
     DJANGO_DANDI_WEB_APP_URL                       = "https://staging--lincbrain-org.netlify.app"
     DJANGO_DANDI_API_URL                           = "https://staging-api.lincbrain.org"
     DJANGO_DANDI_JUPYTERHUB_URL                    = "https://hub.dandiarchive.org/"

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -35,10 +35,6 @@ module "api_staging" {
     DJANGO_DANDI_DANDISETS_EMBARGO_BUCKET_PREFIX   = ""
     DJANGO_DANDI_DANDISETS_LOG_BUCKET_NAME         = module.staging_lincset_bucket_us_east_2.log_bucket_name
     DJANGO_DANDI_DANDISETS_EMBARGO_LOG_BUCKET_NAME = module.staging_embargo_bucket_us_east_2.log_bucket_name
-    DJANGO_DANDI_DOI_API_URL                       = "https://api.test.datacite.org/dois"
-    DJANGO_DANDI_DOI_API_USER                      = "dartlib.dandi"
-    DJANGO_DANDI_DOI_API_PREFIX                    = "10.80507"
-    DJANGO_DANDI_DOI_PUBLISH                       = "false"
     DJANGO_SENTRY_DSN                              = "https://833c159dc622528b21b4ce4adef6dbf8@o4506237212033024.ingest.sentry.io/4506237213212672"
     DJANGO_SENTRY_ENVIRONMENT                      = "staging"
     DJANGO_CELERY_WORKER_CONCURRENCY               = "2"
@@ -50,7 +46,6 @@ module "api_staging" {
     WEBKNOSSOS_ORGANIZATION_NAME                   = "LINC_Staging"
   }
   additional_sensitive_django_vars = {
-    DJANGO_DANDI_DOI_API_PASSWORD = "temp"
   }
 }
 


### PR DESCRIPTION
This PR is comparable to https://github.com/dandi/dandi-infrastructure/pull/224 in https://github.com/dandi/dandi-infrastructure. See commit message for details.

TODOs:

- [x] `DANDI_INSTANCE_NAME` env var is set to `"LINC"` for both production and staging. Make sure that it is the proper value
    - [x] The value of `"LINC-STAGING"` is used for the staging instance.
- ~~[ ] `DANDI_DOI_PREFIX` env var is set to `"10.80507"` in staging. Make sure that it is the proper value.~~
- [x] dandi-archive being able to set the config from DJANGO_DANDI_ variables (PR: TODO)
- [x] Add environment variable needed for vendorization of the publisher for `to_datacite`, https://github.com/dandi/dandi-schema/issues/303

Note: all DOI related environment vars have been removed. See individual commit messages for details.